### PR TITLE
Compatibility with WordPress 4.5

### DIFF
--- a/engine/lithium/lithium.js
+++ b/engine/lithium/lithium.js
@@ -1,7 +1,7 @@
 // Smooth scrolling
 jQuery(function() {
   //only target navigation menus
-  jQuery('nav a[href*=#]:not([href=#]),.nav a[href*=#]:not([href=#])').click(function() {
+  jQuery('nav a[href*="#"]:not([href="#"]),.nav a[href*="#"]:not([href="#"])').click(function() {
     if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
       var target = jQuery(this.hash);
       var navbar = jQuery('.navbar').height() + 10; // minus navbar height


### PR DESCRIPTION
Since the jQuery bundled within the WordPress 4.5 has been updated to
1.12.3, there is an error that break the script.

The error that caused this problem come from the selector in lithium.js.
By wrapping the hash symbol in quote, this should fix the error.
