### PR TITLE
Activating Open Collective

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+<!-- Love onepager? Please consider supporting our collective:
+👉  https://opencollective.com/onepager/donate -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Onepager [![Join the chat at https://gitter.im/themexpert/onepager](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/themexpert/onepager)
+## Onepager [![Backers on Open Collective](https://opencollective.com/onepager/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/onepager/sponsors/badge.svg)](#sponsors) [![Join the chat at https://gitter.im/themexpert/onepager](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/themexpert/onepager)
 Download - (http://getonepager.com/#download)
 
 
@@ -56,3 +56,57 @@ Onepager is maintained by using the [Semantic Versioning Specification (SemVer)]
 ## Copyright and License
 
 Copyright [ThemeXpert](http://www.themexpert.com) under the [GNU GPLv3](http://www.gnu.org/licenses/gpl.html) or later.
+
+
+## Backers
+
+Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/onepager#backer)]
+
+<a href="https://opencollective.com/onepager/backer/0/website" target="_blank"><img src="https://opencollective.com/onepager/backer/0/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/1/website" target="_blank"><img src="https://opencollective.com/onepager/backer/1/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/2/website" target="_blank"><img src="https://opencollective.com/onepager/backer/2/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/3/website" target="_blank"><img src="https://opencollective.com/onepager/backer/3/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/4/website" target="_blank"><img src="https://opencollective.com/onepager/backer/4/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/5/website" target="_blank"><img src="https://opencollective.com/onepager/backer/5/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/6/website" target="_blank"><img src="https://opencollective.com/onepager/backer/6/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/7/website" target="_blank"><img src="https://opencollective.com/onepager/backer/7/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/8/website" target="_blank"><img src="https://opencollective.com/onepager/backer/8/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/9/website" target="_blank"><img src="https://opencollective.com/onepager/backer/9/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/10/website" target="_blank"><img src="https://opencollective.com/onepager/backer/10/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/11/website" target="_blank"><img src="https://opencollective.com/onepager/backer/11/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/12/website" target="_blank"><img src="https://opencollective.com/onepager/backer/12/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/13/website" target="_blank"><img src="https://opencollective.com/onepager/backer/13/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/14/website" target="_blank"><img src="https://opencollective.com/onepager/backer/14/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/15/website" target="_blank"><img src="https://opencollective.com/onepager/backer/15/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/16/website" target="_blank"><img src="https://opencollective.com/onepager/backer/16/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/17/website" target="_blank"><img src="https://opencollective.com/onepager/backer/17/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/18/website" target="_blank"><img src="https://opencollective.com/onepager/backer/18/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/19/website" target="_blank"><img src="https://opencollective.com/onepager/backer/19/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/20/website" target="_blank"><img src="https://opencollective.com/onepager/backer/20/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/21/website" target="_blank"><img src="https://opencollective.com/onepager/backer/21/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/22/website" target="_blank"><img src="https://opencollective.com/onepager/backer/22/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/23/website" target="_blank"><img src="https://opencollective.com/onepager/backer/23/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/24/website" target="_blank"><img src="https://opencollective.com/onepager/backer/24/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/25/website" target="_blank"><img src="https://opencollective.com/onepager/backer/25/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/26/website" target="_blank"><img src="https://opencollective.com/onepager/backer/26/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/27/website" target="_blank"><img src="https://opencollective.com/onepager/backer/27/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/28/website" target="_blank"><img src="https://opencollective.com/onepager/backer/28/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/backer/29/website" target="_blank"><img src="https://opencollective.com/onepager/backer/29/avatar.svg"></a>
+
+
+## Sponsors
+
+Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/onepager#sponsor)]
+
+<a href="https://opencollective.com/onepager/sponsor/0/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/0/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/1/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/1/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/2/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/2/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/3/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/3/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/4/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/4/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/5/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/5/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/6/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/6/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/7/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/7/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/8/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/8/avatar.svg"></a>
+<a href="https://opencollective.com/onepager/sponsor/9/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/9/avatar.svg"></a>
+
+

--- a/README.md
+++ b/README.md
@@ -53,11 +53,6 @@ Each time you want to work on a fix or a new feature, create a new branch based 
 
 Onepager is maintained by using the [Semantic Versioning Specification (SemVer)](http://semver.org).
 
-## Copyright and License
-
-Copyright [ThemeXpert](http://www.themexpert.com) under the [GNU GPLv3](http://www.gnu.org/licenses/gpl.html) or later.
-
-
 ## Backers
 
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/onepager#backer)]
@@ -110,3 +105,6 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 <a href="https://opencollective.com/onepager/sponsor/9/website" target="_blank"><img src="https://opencollective.com/onepager/sponsor/9/avatar.svg"></a>
 
 
+## Copyright and License
+
+Copyright [ThemeXpert](http://www.themexpert.com) under the [GNU GPLv3](http://www.gnu.org/licenses/gpl.html) or later.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "scripts": {
     "start": "gulp",
     "dev": "TARGET=dev webpack --watch --devtool eval --progress --colors --hot",
-    "build": "TARGET=build webpack -p"
+    "build": "TARGET=build webpack -p",
+    "postinstall": "opencollective postinstall"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
@@ -63,6 +64,7 @@
     "immutable": "^3.7.4",
     "lodash": "^3.9.3",
     "object-assign": "^2.0.0",
+    "opencollective": "^1.0.3",
     "react": "^0.13.2",
     "react-bootstrap": "^0.21.2",
     "react-router": "^0.13.3",
@@ -72,5 +74,10 @@
     "tinycolor2": "^1.1.2",
     "underscore": "^1.8.3",
     "underscore.string": "^3.1.1"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/onepager",
+    "logo": "https://opencollective.com/opencollective/logo.txt"
   }
 }


### PR DESCRIPTION
This pull request adds backers and sponsors from your Open Collective https://opencollective.com/onepager ❤️
  
  It adds two badges at the top to show the latest number of backers and sponsors. It also adds placeholders so that the avatar/logo of new backers/sponsors can automatically be shown without having to update your README.md. [[more info](https://github.com/opencollective/opencollective/wiki/Github-banner)]. See how it looks on [this repo](https://github.com/apex/apex#backers).
  
  You can also add a "Donate" button to your website and automatically show your backers and sponsors there with our widgets. Have a look here: https://opencollective.com/widgets
  
We have also added a `postinstall` script to let people know after `npm|yarn install` that you are welcoming donations. [[More info](https://github.com/OpenCollective/opencollective-cli)]