### PR TITLE
Use home_url() instead of $_SERVER to get the host name in get_current_page_url()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -107,21 +107,7 @@ if ( ! function_exists( 'untrailingslashit' ) ) {
 if ( ! function_exists( 'get_current_page_url' ) ) {
 
   function get_current_page_url() {
-    $pageURL = 'http';
-
-    if ( array_key_exists( 'HTTPS', $_SERVER ) && $_SERVER["HTTPS"] == "on" ) {
-      $pageURL = "https";
-    }
-
-    $pageURL .= "://";
-
-    if ( $_SERVER["SERVER_PORT"] != "80" ) {
-      $pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
-    } else {
-      $pageURL .= $_SERVER["SERVER_NAME"] . $_SERVER["REQUEST_URI"];
-    }
-
-    return $pageURL;
+    return home_url() . $_SERVER["REQUEST_URI"];
   }
 }
 


### PR DESCRIPTION
I saw the following error when starting up the editor.

```
Fatal error: Uncaught RuntimeException: Invalid host label, check its content in 
/var/www/html/wp-content/plugins/tx-onepager/vendor/league/url/src/Components/Host.php:164
```
It means that the verification of the host name failed.

ref:
https://github.com/themexpert/onepager/blob/develop/src/functions.php#L73-L79

Depending on web server configuration, $_SERVER ['SERVER_NAME'] may return the following values:
	
```
*.example.com
```

In this case, the editor will not start and an error will be output.

I suggest using `home_url()` instead of `$_SERVER['SERVER_NAME']` to get the current page URL in `get_current_page_url()`.

Thanks.